### PR TITLE
fix: prevent re-renders when the computed value does not changes

### DIFF
--- a/src/modules/computed.ts
+++ b/src/modules/computed.ts
@@ -21,8 +21,12 @@ export class Computed<T> {
   }
 
   private recalculate = () => {
-    this._value = this.callback();
-    this.forceRender();
+    const nv = this.callback();
+
+    if (!Object.is(nv, this._value)) {
+      this._value = nv;
+      this.forceRender();
+    }
   };
 
   private handleDepUpdate = () => {

--- a/src/modules/external-store.ts
+++ b/src/modules/external-store.ts
@@ -29,7 +29,7 @@ export class ExternalStore<T> {
 
   private handleUpdate() {
     const value = this.getSnapshot();
-    if (value !== this.value) {
+    if (!Object.is(value, this.value)) {
       this.value = value;
       this._main.forceUpdate();
     }


### PR DESCRIPTION
Prevented component re-renders in situations where the value returned by the callback of `$computed` did not change since last time.