### PR TITLE
fix: context map decorator

### DIFF
--- a/src/context-decorator.tsx
+++ b/src/context-decorator.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 export const MapContext =
   (context: Record<string, React.Context<any>>) =>
-  (Component: any, _: any) => {
+  (Component: any, _?: any) => {
     const ctxEntries = Object.entries(context);
 
     const getJsxElem = ctxEntries.reduce(
@@ -11,19 +11,18 @@ export const MapContext =
         elem: (additionalProps: Record<string, any>) => JSX.Element,
         [name, ctx],
       ) => {
-        return (additionalProps: Record<string, any>) =>
-          React.createElement(
-            ctx.Consumer,
-            undefined,
-            // @ts-expect-error
-            (ctxValue: any) => {
+        return (additionalProps: Record<string, any>) => (
+          <ctx.Consumer>
+            {(ctxValue: any) => {
               additionalProps["__ctx_" + name] = ctxValue;
               return elem(additionalProps);
-            },
-          );
+            }}
+          </ctx.Consumer>
+        );
       },
-      (additionalProps: Record<string, any>) =>
-        React.createElement(Component, additionalProps),
+      (additionalProps: Record<string, any>) => (
+        <Component {...additionalProps} />
+      ),
     );
 
     return class ContextInjector extends React.Component {


### PR DESCRIPTION
Updated the `@MapContext` decorator which should allow to use it with either ECMAScript as well as TS-experimental deocrators.